### PR TITLE
Add focus-in event handling on the sb.input

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,9 +163,10 @@ Attributes:
 * `placeholder`
 * `readonly`
 * `disabled`
-* `on-input` fired when text is input
-* `on-delete` fired when there is no text, but backspace is pressed
 * `on-clear` fired when text is cleared
+* `on-delete` fired when there is no text, but backspace is pressed
+* `on-focus` fired when input gets focus
+* `on-input` fired when text is input
 
 
 ##### Selected option

--- a/addon/components/select-box/input.js
+++ b/addon/components/select-box/input.js
@@ -34,5 +34,13 @@ export default Component.extend(
     if (e.which === 8 && !this.$().val()) {
       this.sendAction('on-delete', this.getAttr('-api'));
     }
+  },
+
+  focusIn: function() {
+    this._super(...arguments);
+    let func = this.attrs['focus-in'];
+    if (typeof func === 'function') {
+      func();
+    }
   }
 });

--- a/tests/integration/components/input-test.js
+++ b/tests/integration/components/input-test.js
@@ -186,3 +186,29 @@ test('on-delete action', function(assert) {
     'delete action is only fired when value is blank & backspace is pressed');
 });
 
+test('on-focus action', function(assert) {
+  assert.expect(1);
+
+  let count = 0;
+
+  this.on('focused', () => {
+    count++;
+  });
+
+  this.render(hbs `
+    {{#select-box as |sb|}}
+      {{sb.input value='f' focus-in=(action 'focused')}}
+    {{/select-box}}
+  `);
+  this.$('.select-box-input').trigger('focus');
+
+  this.render(hbs `
+    {{#select-box as |sb|}}
+      {{sb.input value='f'}}
+    {{/select-box}}
+  `);
+  this.$('.select-box-input').trigger('focus');
+
+  assert.equal(count, 1, 'fires focus-in callback on focusIn event only when focus-in value is a function');
+});
+


### PR DESCRIPTION
This PR adds a `focus-in` handling for the `sb.input`.
Possible use-case is a data preloading before user started typing. 
