### PR TITLE
Fix tag-select example

### DIFF
--- a/tests/dummy/app/templates/components/tag-select.hbs
+++ b/tests/dummy/app/templates/components/tag-select.hbs
@@ -27,7 +27,7 @@
   {{sb.input
     click=(action "reveal" sb @on-search)
     on-input=sb.open
-    on-delete=(action "removeTag" sb.value.lastObject)
+    on-delete=(action "removeTag" value.lastObject)
     autofocus=true}}
 
   {{#if sb.isOpen}}


### PR DESCRIPTION
There is a confusion between `value` and `sb.value` which leads to a bug.
Reproduction steps:
- Go to https://zestia.github.io/ember-select-box/#/tag-select
- Click on the input to show the options
- Click on one option (eg. `foo`)
- Click again on the input
- Try to press backspace
---> You cannot delete `baz` anymore

I think that you lose the reference to the array using `sb.value` but `value` still get the good reference.
 